### PR TITLE
feat: add agent manager and multi-agent routing

### DIFF
--- a/server/agents/manager.py
+++ b/server/agents/manager.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Agent manager module."""
+
+from typing import Dict, List, Optional
+import uuid
+
+from .core import Agent
+
+
+class AgentManager:
+    """Manage multiple :class:`Agent` instances keyed by agent IDs."""
+
+    def __init__(self) -> None:
+        self._agents: Dict[str, Agent] = {}
+
+    def create_agent(self) -> str:
+        """Create a new agent and return its identifier."""
+        agent_id = str(uuid.uuid4())
+        agent = Agent()
+        self._agents[agent_id] = agent
+        return agent_id
+
+    def get_agent(self, agent_id: str) -> Optional[Agent]:
+        """Retrieve an existing agent by ID."""
+        return self._agents.get(agent_id)
+
+    def list_agents(self) -> List[str]:
+        """Return list of active agent IDs."""
+        return list(self._agents.keys())
+
+    async def remove_agent(self, agent_id: str) -> bool:
+        """Remove an agent by ID and close its resources.
+
+        Returns ``True`` if the agent was removed, ``False`` otherwise.
+        """
+        agent = self._agents.pop(agent_id, None)
+        if not agent:
+            return False
+        try:
+            await agent.http_client.aclose()
+        except Exception:
+            # Ignore errors during cleanup
+            pass
+        return True

--- a/server/agents/schemas.py
+++ b/server/agents/schemas.py
@@ -11,6 +11,7 @@ class Message(BaseModel):
 class ChatRequest(BaseModel):
     messages: List[Message]
     conversation_id: Optional[str] = None
+    agent_id: str
     enable_browsing: bool = False
     system: Optional[str] = None
     temperature: float = Field(default=0.7, ge=0.0, le=2.0)

--- a/server/app.py
+++ b/server/app.py
@@ -12,6 +12,7 @@ import os
 
 from agents.settings import settings
 from agents.schemas import ChatRequest, ChatResponse, ModelInfo, HealthResponse
+from agents.manager import AgentManager
 from agents.core import Agent
 from agents.memory import ConversationManager
 from agents.util import create_sse_data
@@ -37,7 +38,7 @@ app.add_middleware(
 )
 
 # Initialize components
-agent = Agent()
+agent_manager = AgentManager()
 conversation_manager = ConversationManager()
 
 @app.on_event("startup")
@@ -65,6 +66,24 @@ async def health_check():
         model_id=settings.model_id
     )
 
+@app.post("/agents")
+async def create_agent():
+    """Create a new agent instance"""
+    agent_id = agent_manager.create_agent()
+    return {"agent_id": agent_id}
+
+@app.get("/agents")
+async def list_agents_endpoint():
+    """List active agent IDs"""
+    return {"agents": agent_manager.list_agents()}
+
+@app.delete("/agents/{agent_id}")
+async def delete_agent(agent_id: str):
+    """Remove an agent instance"""
+    removed = await agent_manager.remove_agent(agent_id)
+    if not removed:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    return {"message": "Agent removed"}
 @app.get("/models", response_model=list[ModelInfo])
 async def list_models():
     """List available Ollama models"""
@@ -92,6 +111,12 @@ async def list_models():
 async def chat_endpoint(request: ChatRequest):
     """Main chat endpoint with streaming response"""
     try:
+        if not request.agent_id:
+            raise HTTPException(status_code=400, detail="agent_id required")
+        agent = agent_manager.get_agent(request.agent_id)
+        if not agent:
+            raise HTTPException(status_code=404, detail="Agent not found")
+
         # Validate conversation exists or create new one
         if request.conversation_id:
             conversation = await conversation_manager.get_conversation(request.conversation_id)
@@ -116,7 +141,7 @@ async def chat_endpoint(request: ChatRequest):
 
         # Generate streaming response
         return StreamingResponse(
-            stream_chat_response(request),
+            stream_chat_response(request, agent),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",
@@ -124,11 +149,13 @@ async def chat_endpoint(request: ChatRequest):
                 "Access-Control-Allow-Origin": "*",
             }
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Chat error: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
-async def stream_chat_response(request: ChatRequest) -> AsyncGenerator[str, None]:
+async def stream_chat_response(request: ChatRequest, agent: Agent) -> AsyncGenerator[str, None]:
     """Stream chat response using Server-Sent Events"""
     try:
         # Run agent with streaming
@@ -181,7 +208,21 @@ async def websocket_endpoint(websocket: WebSocket):
             try:
                 request_data = json.loads(data)
                 request = ChatRequest(**request_data)
-                
+
+                if not request.agent_id:
+                    await websocket.send_text(json.dumps({
+                        "type": "error",
+                        "content": "agent_id required"
+                    }))
+                    continue
+                agent = agent_manager.get_agent(request.agent_id)
+                if not agent:
+                    await websocket.send_text(json.dumps({
+                        "type": "error",
+                        "content": "Agent not found"
+                    }))
+                    continue
+
                 # Process with agent
                 async for chunk in agent.run_streaming(
                     messages=request.messages,

--- a/server/tests/test_agent_manager.py
+++ b/server/tests/test_agent_manager.py
@@ -1,0 +1,88 @@
+import json
+import sys
+import importlib
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """Create a TestClient with isolated temp directory and database."""
+    server_dir = Path(__file__).resolve().parents[1]
+    sys.path.append(str(server_dir))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DATABASE_PATH", str(tmp_path / "conversations.db"))
+    app_module = importlib.reload(importlib.import_module("app"))
+    with TestClient(app_module.app) as client:
+        yield client
+
+
+def test_agent_creation_and_listing(client):
+    resp = client.post("/agents")
+    assert resp.status_code == 200
+    agent_id = resp.json()["agent_id"]
+
+    resp = client.get("/agents")
+    assert resp.status_code == 200
+    assert agent_id in resp.json()["agents"]
+
+
+def test_message_routing_and_teardown(client, monkeypatch):
+    from agents.core import Agent
+    app_module = importlib.import_module("app")
+
+    agent_id1 = client.post("/agents").json()["agent_id"]
+    agent_id2 = client.post("/agents").json()["agent_id"]
+
+    agent1 = app_module.agent_manager.get_agent(agent_id1)
+    agent2 = app_module.agent_manager.get_agent(agent_id2)
+    token_map = {agent1: agent_id1, agent2: agent_id2}
+
+    async def fake_run_streaming(self, *args, **kwargs):
+        yield {"type": "token", "content": token_map[self]}
+        return
+
+    monkeypatch.setattr(Agent, "run_streaming", fake_run_streaming)
+
+    payload = {"messages": [{"role": "user", "content": "hi"}], "agent_id": agent_id1}
+    resp1 = client.post("/chat", json=payload)
+    assert agent_id1 in resp1.text
+
+    payload["agent_id"] = agent_id2
+    resp2 = client.post("/chat", json=payload)
+    assert agent_id2 in resp2.text
+
+    # delete first agent and ensure further chat fails
+    del_resp = client.delete(f"/agents/{agent_id1}")
+    assert del_resp.status_code == 200
+
+    resp_deleted = client.post(
+        "/chat",
+        json={"messages": [{"role": "user", "content": "hi"}], "agent_id": agent_id1},
+    )
+    assert resp_deleted.status_code == 404
+
+
+def test_websocket_routing(client, monkeypatch):
+    from agents.core import Agent
+    app_module = importlib.import_module("app")
+
+    agent_id = client.post("/agents").json()["agent_id"]
+    agent = app_module.agent_manager.get_agent(agent_id)
+    token_map = {agent: agent_id}
+
+    async def fake_run_streaming(self, *args, **kwargs):
+        yield {"type": "token", "content": token_map[self]}
+        return
+
+    monkeypatch.setattr(Agent, "run_streaming", fake_run_streaming)
+
+    with client.websocket_connect("/ws") as ws:
+        message = {"messages": [{"role": "user", "content": "hi"}], "agent_id": agent_id}
+        ws.send_text(json.dumps(message))
+        response = json.loads(ws.receive_text())
+        assert response["content"] == agent_id
+        done = json.loads(ws.receive_text())
+        assert done["type"] == "done"


### PR DESCRIPTION
## Summary
- add `AgentManager` to create, list and remove agents
- expose `/agents` CRUD endpoints and route `/chat` & `/ws` via `agent_id`
- require `agent_id` in chat requests and use public APIs in tests
- cover agent lifecycle and routing in tests
- clean up agent resources on removal without mutating agent instances

## Testing
- `pytest server/tests/test_agent_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc04ccfee883328b8e3d3213cdbe46